### PR TITLE
fix #156 Reference from another file don't work

### DIFF
--- a/ng-swagger-gen.js
+++ b/ng-swagger-gen.js
@@ -6,7 +6,7 @@
 const fs = require('fs');
 const path = require('path');
 const Mustache = require('mustache');
-const $RefParser = require('json-schema-ref-parser');
+const $RefParser = require('@apidevtools/swagger-parser');
 var npmConfig = require('npm-conf');
 
 /**
@@ -22,22 +22,23 @@ function ngSwaggerGen(options) {
     setupProxy();
   }
 
-  $RefParser.bundle(options.swagger,
-    { dereference: { circular: false },
-    resolve: { http: { timeout: options.timeout } } }).then(
-    data => {
-      doGenerate(data, options);
-    },
-    err => {
-      console.error(
-        `Error reading swagger location ${options.swagger}: ${err}`
-      );
+  $RefParser.dereference(options.swagger,
+    { dereference: { circular: false},
+    resolve: { http: { timeout: options.timeout } } })
+    .then(
+      data => {
+        doGenerate(data, options);
+      },
+      err => {
+        console.error(
+          `Error reading swagger location ${options.swagger}: ${err}`
+        );
+      })
+    .catch(function (error) {
+      console.error(`Error while dereferening: ${error}`);
       process.exit(1);
-    }
-  ).catch(function (error) {
-    console.error(`Error: ${error}`);
-    process.exit(1);
-  });
+    });
+
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,45 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.6",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "@apidevtools/openapi-schemas": {
+      "version": "2.0.4",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/@apidevtools/openapi-schemas/-/openapi-schemas-2.0.4.tgz",
+      "integrity": "sha512-ob5c4UiaMYkb24pNhvfSABShAwpREvUGCkqjiz/BX9gKZ32y/S22M+ALIHftTAuv9KsFVSpVdIDzi9ZzFh5TCA=="
+    },
+    "@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "@apidevtools/swagger-parser": {
+      "version": "10.0.1",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/@apidevtools/swagger-parser/-/swagger-parser-10.0.1.tgz",
+      "integrity": "sha512-P5nva6hpXCK5NByGXbIJnFxd5FhQI9LGs+If0SMgKV+/5qlZnHH/B/6GtfnSPwSViRPL+7ARSzMcYIfGwjkW5Q==",
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.5",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "openapi-types": "^1.3.5",
+        "z-schema": "^4.2.3"
+      }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -22,6 +61,12 @@
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "optional": true
+    },
     "config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -35,14 +80,6 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
       "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-    },
-    "debug": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -76,11 +113,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
     },
     "global-agent": {
       "version": "2.1.12",
@@ -121,23 +153,20 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
     },
     "json-schema-ref-parser": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz",
-      "integrity": "sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==",
+      "version": "9.0.6",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+      "integrity": "sha512-z0JGv7rRD3CnJbZY/qCpscyArdtLJhr/wRBmFUdoZ8xMjsFyNdILSprG2degqRLjBjyhZHAEBpGOxniO9rKTxA==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "debug": "^3.1.0",
-        "js-yaml": "^3.12.0",
-        "ono": "^4.0.6"
+        "@apidevtools/json-schema-ref-parser": "9.0.6"
       }
     },
     "json-stringify-safe": {
@@ -150,6 +179,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -158,15 +197,10 @@
         "escape-string-regexp": "^4.0.0"
       }
     },
-    "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-    },
     "mustache": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
-      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
+      "version": "4.0.1",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
     },
     "npm-conf": {
       "version": "1.1.3",
@@ -182,13 +216,10 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
-    "ono": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.8.tgz",
-      "integrity": "sha512-x7IM7JLrarP9WxfjDHTBs6io1D1ixEZnhKqnjMnwz+9waPZSapkGYe7jBAqnMTL+HAMfsN6rSHW3Pi+C/9dyjg==",
-      "requires": {
-        "format-util": "^1.0.3"
-      }
+    "openapi-types": {
+      "version": "1.3.5",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/openapi-types/-/openapi-types-1.3.5.tgz",
+      "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
     },
     "pify": {
       "version": "3.0.0",
@@ -252,6 +283,22 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+    },
+    "validator": {
+      "version": "12.2.0",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/validator/-/validator-12.2.0.tgz",
+      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
+    },
+    "z-schema": {
+      "version": "4.2.3",
+      "resolved": "https://nexus3.kb.cz/repository/npm-all/z-schema/-/z-schema-4.2.3.tgz",
+      "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^12.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "url": "git+https://github.com/cyclosproject/ng-swagger-gen.git"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^10.0.1",
     "argparse": "^1.0.10",
     "global-agent": "^2.1.12",
     "global-tunnel-ng": "^2.7.1",
-    "json-schema-ref-parser": "^5.1.3",
-    "mustache": "^2.3.2",
+    "json-schema-ref-parser": "^9.0.6",
+    "mustache": "^4.0.1",
     "npm-conf": "^1.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
In order to support $ref that references objects in external files, change json-schema-ref-parser to @apidevtools/swagger-parser and use dereference function instead of bundle.
Dereference function replaces each reference with its resolved value.